### PR TITLE
Update ingress API version

### DIFF
--- a/charts/freqtrade/templates/ingress.yaml
+++ b/charts/freqtrade/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: freqtrade


### PR DESCRIPTION
Fixes the following error:

```
Error:  templates/ingress.yaml: the kind "extensions/v1beta1 Ingress" is deprecated in favor of "networking.k8s.io/v1beta1 Ingress"
```